### PR TITLE
Decklist printing

### DIFF
--- a/Scryfall Tools/decklist_parser.py
+++ b/Scryfall Tools/decklist_parser.py
@@ -34,7 +34,7 @@ def parse_decklist(file):
             continue
 
         ## Match many types of decklist entries
-        regex = r'(\d{0,3})x?\b ?(.+?)(?:\n|(?: (?:[\(\[](\w{3,5})[\)\]] ?([\w*]*))))'
+        regex = r'(\d{0,3})x?\b ?(.+?)(?:$| (?:[([](\w*)[)\]] ?(\w*).*))'
         ma = re.search(regex, line)
         count = int(ma.group(1)) if ma.group(1) else 1
 

--- a/Scryfall Tools/decklist_parser.py
+++ b/Scryfall Tools/decklist_parser.py
@@ -34,7 +34,7 @@ def parse_decklist(file):
             continue
 
         ## Match many types of decklist entries
-        regex = r'(\d*)x? ?([^\(\)\[\]\n]+)(?:[\(\[](.*)[\)\]] ?([0-z]*)(.*))?'
+        regex = r'(\d{0,3})x?\b ?([^\(\)\[\]\n]+)(?: ?[\(\[]([^\(\)\[\]\n ]+)[\)\]] ?([0-z]*)(.*))?'
         ma = re.search(regex, line)
         count = int(ma.group(1)) if ma.group(1) else 1
 

--- a/Scryfall Tools/decklist_parser.py
+++ b/Scryfall Tools/decklist_parser.py
@@ -4,7 +4,6 @@
 
 import os
 import re
-from scryfall_tools import get_collection
 
 import sys
 

--- a/Scryfall Tools/decklist_parser.py
+++ b/Scryfall Tools/decklist_parser.py
@@ -34,7 +34,7 @@ def parse_decklist(file):
             continue
 
         ## Match many types of decklist entries
-        regex = r'(\d{0,3})x?\b ?([^\(\)\[\]\n]+)(?: ?[\(\[]([^\(\)\[\]\n ]+)[\)\]] ?([0-z]*)(.*))?'
+        regex = r'(\d{0,3})x?\b ?(.+?)(?:\n|(?: (?:[\(\[](\w{3,5})[\)\]] ?([\w*]*))))'
         ma = re.search(regex, line)
         count = int(ma.group(1)) if ma.group(1) else 1
 

--- a/Scryfall Tools/decklist_parser.py
+++ b/Scryfall Tools/decklist_parser.py
@@ -1,0 +1,63 @@
+# Parses Magic: The Gathering decklists for cards, counts and printings.
+# Returns seperate lists for main deck and sideboard.
+# List entries are tuples of card identifiers and count.
+
+import os
+import re
+from scryfall_tools import get_collection
+
+import sys
+
+def parse_decklist(file):
+    ## Get the main deck name
+    deck_name = os.path.splitext(os.path.basename(file.name))[0]
+
+    ## Start parsing the decklist
+    line = file.readline()
+    decks = {}
+    deck = []
+    sideboard = False
+    while line:
+        ## If the line is a comment, continue to the next line
+        if line.startswith('//'):
+            line = file.readline()
+            continue
+
+        ## The first empty line signifies the start of the sideboard
+        ## Any empty line should be ignored
+        if not line.strip():
+            if not sideboard:
+                decks[deck_name] = deck
+                deck_name += ' (sideboard)'
+                deck = []
+                sideboard = True
+            line = file.readline()
+            continue
+
+        ## Match many types of decklist entries
+        regex = r'(\d*)x? ?([^\(\)\[\]\n]+)(?:[\(\[](.*)[\)\]] ?([0-z]*)(.*))?'
+        ma = re.search(regex, line)
+        count = int(ma.group(1)) if ma.group(1) else 1
+
+        card_dict = {}
+        ## If the set and collectors number are specified, use this information.
+        if ma.group(4) and ma.group(3):
+            card_dict['collector_number'] = ma.group(4)
+        ## Otherwise, use the card name.
+        else:
+            card_dict['name'] = ma.group(2)
+        ## In any case, if a set is specified, use this.
+        if ma.group(3):
+            card_dict['set'] = ma.group(3)
+
+        deck.append((card_dict, count))
+        line = file.readline()
+    
+    ## Add the final deck to the list
+    decks[deck_name] = deck
+
+    return decks
+
+if __name__ == '__main__':
+    decks = parse_decklist(open(sys.argv[1], mode='r'))
+    print(decks)

--- a/Scryfall Tools/main.py
+++ b/Scryfall Tools/main.py
@@ -6,6 +6,7 @@ from datetime import date
 from TTS_MTG_deck_creator import create_tts_mtg_decks
 from constants import CARD_SIZES
 from limited_pools import get_limited_pool
+from decklist_parser import parse_decklist
 from random_commander_deck import create_random_commander_deck
 from scryfall_tools import get_collection
 
@@ -54,21 +55,13 @@ def main(
         decks = get_sealed_pool(set_code=set_code)
 
 def decklist(args):
-    # Handle sideboards, sets
-    deck_name = os.path.splitext(os.path.basename(args.file.name))[0]
-    decklist_array = args.file.readlines()
-
-    # Flip decklist_array ['[amount] [cardname]']
-    # to {[cardname]: [amount]}
-    deck_dict = {
-        ' '.join(entry.split(' ')[1:]).strip()
-        : int(entry.split(' ')[0])
-        for entry in decklist_array
-        if entry.strip() and not entry.startswith('//')
-    }
+    decks = parse_decklist(args.file)
+    collected_decks = {}
+    for deckname, decklist in decks.items():
+        collected_decks[deckname] = get_collection(decklist)
 
     create_tts_mtg_decks(
-        decks={deck_name: get_collection(deck_dict)},
+        decks=collected_decks,
         path=args.out,
         card_size_text=args.size,
     )

--- a/Scryfall Tools/random_commander_deck.py
+++ b/Scryfall Tools/random_commander_deck.py
@@ -34,12 +34,12 @@ def get_edhrec_average_deck(commander):
 
     decklist_raw = list_cards.split('\n')
     pattern = re.compile(r'(\d*) (.*)$')
-    decklist_filtered = {
-        match.group(2): int(match.group(1))
+    decklist_filtered = [
+        ({'name' : match.group(2)}, int(match.group(1)))
         for match in (pattern.match(entry) for entry in decklist_raw) if match
-    }
+    ]
 
-    if sum(decklist_filtered.values()) != 100:
+    if sum([count for card, count in decklist_filtered]) != 100:
         print('The found decklist is incomplete')
         return None
 
@@ -64,11 +64,11 @@ def create_random_commander_deck(query='', verbose=False, deck_name=''):
     pf = project_config['Main'].get('deckname_prefix')
     deck_name = deck_name or f'{pf} {random_commander["name"].split(" //")[0]}'
 
-    deck_dict = get_edhrec_average_deck(random_commander)
+    deck_array = get_edhrec_average_deck(random_commander)
 
-    if not deck_dict:
+    if not deck_array:
         return None, ''
 
-    decklist = get_collection(deck_dict)
+    decklist = get_collection(deck_array)
 
     return decklist, deck_name

--- a/Scryfall Tools/scryfall_tools.py
+++ b/Scryfall Tools/scryfall_tools.py
@@ -81,7 +81,7 @@ def search_for_cards(query):
         return [card for lst in stored for card in lst]
 
 
-def get_collection(decklist_dict):
+def get_collection(decklist):
     """Return a dictionary of identifiers for posting to Scryfall.
     See https://scryfall.com/docs/api/cards/collection
     """
@@ -89,11 +89,14 @@ def get_collection(decklist_dict):
     results = []
     identifiers = []
 
-    for idx, (cardname, count) in enumerate(decklist_dict.items()):
-        card_identifier = cardname_identifier_overrides.get(
-            cardname,
-            {'name': cardname}
-        )
+    for idx, (identifier, count) in enumerate(decklist):
+        if 'set' not in identifier.keys():
+            card_identifier = cardname_identifier_overrides.get(
+                identifier['name'],
+                identifier
+            )
+        else:
+            card_identifier = identifier
 
         for _ in range(count):
             identifiers.append(card_identifier)
@@ -101,12 +104,12 @@ def get_collection(decklist_dict):
             # If we reached the limit of Scryfall's collection lookup
             # or the end of the decklist:
             # Retrieve the cards and continue parsing lines.
-            if len(identifiers) == 75 or idx + 1 == len(decklist_dict):
+            if len(identifiers) == 75 or idx + 1 == len(decklist):
                 cards = requests.post(
                     'https://api.scryfall.com/cards/collection',
                     json={'identifiers': identifiers}
-                ).json()
-                results.append(cards)
+                )
+                results.append(cards.json())
                 identifiers = []
 
     # Merge the results

--- a/Scryfall Tools/test_overrides.py
+++ b/Scryfall Tools/test_overrides.py
@@ -8,12 +8,12 @@ from scryfall_tools import get_collection
 
 
 def main(out, name, size):
-    deck_dict = {
-        cardname: 1
+    deck_array = [
+        ({'name': cardname}, 1)
         for cardname in cardname_identifier_overrides.keys()
-    }
+    ]
 
-    decklist = get_collection(deck_dict)
+    decklist = get_collection(deck_array)
 
     create_tts_mtg_decks(
         {name: decklist},


### PR DESCRIPTION
Adds the option to specify the printing of a card in decklist mode.
Closes #1 (see thread for design choices).

> Entries can be formatted as follows:
> `{count{x}} {card name} {(/[set code)/]} {collector number} {##comment}`
> Everything besides `card name` is optional; `x` can't be included without `count`, `collector number` can't be included without `set code`.

Every entry after the first empty line is split into a sideboard.